### PR TITLE
fix: resolve issues #1, #2, #3 (#1)

### DIFF
--- a/content/content.js
+++ b/content/content.js
@@ -104,21 +104,35 @@
     function isExternalElement(element) {
         if (!element) return false;
 
-        // Check for common extension patterns
-        const tagName = element.tagName?.toLowerCase() || '';
+        // Traverse up the DOM tree to check all ancestors
+        let current = element;
+        while (current && current !== document.body && current !== document.documentElement) {
+            // Check for Shadow DOM host — verify it's actually from another extension
+            if (current.shadowRoot) {
+                try {
+                    const hostBaseURI = current.shadowRoot.host?.baseURI || '';
+                    if (hostBaseURI.startsWith('chrome-extension://')) return true;
+                } catch (e) {
+                    // Cross-origin shadow root — likely from another extension
+                    if (current.shadowRoot.host) return true;
+                }
+            }
 
-        // Shadow DOM hosts from other extensions
-        if (element.shadowRoot) return true;
+            // Check for extension-specific attributes
+            if (current.hasAttribute?.('data-extension-id')) return true;
+            if (current.id?.startsWith('crx_')) return true;
 
-        // Elements with extension-specific attributes
-        if (element.closest('[data-extension-id]')) return true;
-        if (element.closest('[class*="extension"]')) return true;
+            // Check for extension-specific classes (specific patterns only, not generic "extension")
+            const classes = current.className && typeof current.className === 'string' ? current.className : '';
+            if (/\b(crx_|chrome-extension|browser-extension)\b/i.test(classes)) return true;
 
-        // WhatsApp Web specific elements
-        if (element.closest('[data-app="web"]')) return true;
-        if (element.closest('#app')) {
-            // Check if it's actually WhatsApp
-            if (window.location.hostname.includes('whatsapp')) return true;
+            current = current.parentElement;
+        }
+
+        // WhatsApp Web specific check
+        if (window.location.hostname.includes('whatsapp')) {
+            if (element.closest('[data-app="web"]')) return true;
+            if (element.closest('#app')) return true;
         }
 
         return false;
@@ -594,8 +608,26 @@
         const element = currentTextBox;
 
         if (element.isContentEditable) {
-            // ContentEditable element
-            document.execCommand('insertText', false, translation);
+            // ContentEditable element — use modern Selection/Range API
+            const selection = window.getSelection();
+            if (selection.rangeCount > 0) {
+                const range = selection.getRangeAt(0);
+                range.deleteContents();
+                const textNode = document.createTextNode(translation);
+                range.insertNode(textNode);
+                // Move cursor after inserted text
+                range.setStartAfter(textNode);
+                range.collapse(true);
+                selection.removeAllRanges();
+                selection.addRange(range);
+            }
+            // Trigger input event for frameworks (React, Vue, etc.)
+            element.dispatchEvent(new InputEvent('input', {
+                bubbles: true,
+                cancelable: true,
+                inputType: 'insertText',
+                data: translation
+            }));
         } else {
             // Input or textarea
             const start = element.selectionStart;

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "AI Translator",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Instant AI-powered translation for selected text. Supports OpenAI, Gemini, DeepSeek, DeepL, and custom APIs.",
   "icons": {
     "16": "icons/icon-16.png",


### PR DESCRIPTION
#1 — Replace deprecated execCommand with Selection/Range API
- Removed document.execCommand('insertText') for contenteditable elements
- Now uses getSelection() + Range API (deleteContents, insertNode, setStartAfter)
- Dispatches InputEvent with inputType/data for proper framework reactivity (React, Vue)

#2 — Fix inaccurate Shadow DOM detection
- Traverse full DOM tree instead of checking only the target element
- Verify Shadow DOM hosts are actually from chrome-extension:// origins
- Handle cross-origin shadow roots gracefully (catch block)
- Replace generic class*='extension' selector with specific patterns (crx_, chrome-extension, browser-extension) to avoid false positives on legitimate content
- Check for crx_ id prefix pattern

#3 — Remove overly broad host_permissions
- Wildcards (https://*/*, http://*/*) already removed in prior commit
- Content scripts with <all_urls> provide sufficient DOM access

Closes #1, Closes #2, Closes #3

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Modernized text insertion for contenteditable fields and improved Shadow DOM detection to reduce false positives from other extensions. Bumps version to 1.3.0 and resolves #1, #2, and #3.

- **Bug Fixes**
  - ContentEditable: replaced `document.execCommand('insertText')` with Selection/Range; moves caret correctly and dispatches `InputEvent` for React/Vue reactivity.
  - Shadow DOM detection: walks ancestors, only treats `chrome-extension://` shadow hosts as external, handles cross-origin safely, and uses specific class/id patterns (`crx_`, `chrome-extension`, `browser-extension`); refined WhatsApp checks.

<sup>Written for commit 7fd59566f62de82aa5d6342c6a73c0e17f6d3da3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

